### PR TITLE
Removed a reference to PL_madskills

### DIFF
--- a/padop_on_crack.c.inc
+++ b/padop_on_crack.c.inc
@@ -489,8 +489,7 @@ func_ops:
 		case OP_AND:
 			kid = cLOGOPo->op_first;
 			if (kid->op_type == OP_NOT
-				&& (kid->op_flags & OPf_KIDS)
-				&& !PL_madskills) {
+				&& (kid->op_flags & OPf_KIDS)) {
 				if (o->op_type == OP_AND) {
 					o->op_type = OP_OR;
 					o->op_ppaddr = PL_ppaddr[OP_OR];


### PR DESCRIPTION
This was removed on Perl 5.21, so it was stopping the
module from build on blead.

On earlier perls, it was only used if perl was compiled
with -Dmad, which outside of some 5.9.x releases,
never quite worked, so removing the check should cause no
breakage in the wild.
