### PR TITLE
Make using -fsanitize an option.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,9 +3,6 @@ export HARNESS_OPTIONS=c
 
 include ./Makefile
 
-CCFLAGS   := $(CCFLAGS) -DDEVEL -fsanitize=address -fsanitize=undefined
-OTHERLDFLAGS := $(OTHERLDFLAGS) -fsanitize=address -fsanitize=undefined
-
 .PHONY: multitest
 multitest:
 	f=''; k=''; \

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,12 @@
 use strict;
 use warnings;
 use ExtUtils::MakeMaker;
+use Getopt::Long;
+
+my $Do_fsanitize;
+GetOptions(
+    "fsanitize!" => \$Do_fsanitize
+);
 
 sub merge_key_into {
     my ($href, $target, $source) = @_;
@@ -78,3 +84,14 @@ if ($mm_version < 6.51_03) {
 }
 
 WriteMakefile %opt;
+
+sub MY::postamble {
+    my $make = '';
+
+    $make .= <<'END' if $Do_fsanitize;
+CCFLAGS   := $(CCFLAGS) -DDEVEL -fsanitize=address -fsanitize=undefined
+OTHERLDFLAGS := $(OTHERLDFLAGS) -fsanitize=address -fsanitize=undefined
+
+END
+
+}


### PR DESCRIPTION
This makes life easier for OS X users to make patches.  It's not their fault Apple broke clang.

I tried to make this a Makefile conditional that checked if `-fsanitize` worked, or looked at `--version` to see if it was Apple clang, but I'm not good with GNU make conditionals.