### PR TITLE
Update the Method::Signatures compatibility tests to use a wrapper.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -62,8 +62,6 @@ my %opt = (
     },
 );
 
-(do 'maint/eumm-fixup.pl' || die $@ || $!)->(\%opt) if !-f 'META.yml';
-
 (my $mm_version = ExtUtils::MakeMaker->VERSION) =~ tr/_//d;
 
 if ($mm_version < 6.67_04) {

--- a/Parameters.xs
+++ b/Parameters.xs
@@ -114,8 +114,9 @@ enum {
     FLAG_TYPES_OK     = 0x040,
     FLAG_CHECK_TARGS  = 0x080,
     FLAG_RUNTIME      = 0x100,
-    FLAG_MSC_QUESTION_MARK_MEANS_OPTIONAL = 0x200,
-    FLAG_MSC_NAMED_OPTIONAL_BY_DEFAULT    = 0x400
+    FLAG_MSC_QUESTION_MARK_MEANS_OPTIONAL     = 0x200,
+    FLAG_MSC_EXCLAIMATION_MARK_MEANS_REQUIRED = 0x400,
+    FLAG_MSC_NAMED_OPTIONAL_BY_DEFAULT        = 0x800
 };
 
 DEFSTRUCT(KWSpec) {
@@ -969,6 +970,12 @@ static PADOFFSET parse_param(
         lex_read_space(0);
 
         op_guard_update(ginit, newOP(OP_UNDEF, 0));
+        c = lex_peek_unichar(0);
+    }
+    else if (c == '!' && spec->flags & FLAG_MSC_EXCLAIMATION_MARK_MEANS_REQUIRED) {
+        lex_read_unichar(0);
+        lex_read_space(0);
+        
         c = lex_peek_unichar(0);
     }
 
@@ -2266,6 +2273,7 @@ WARNINGS_ENABLE {
     newCONSTSUB(stash, "FLAG_CHECK_TARGS",  newSViv(FLAG_CHECK_TARGS));
     newCONSTSUB(stash, "FLAG_RUNTIME",      newSViv(FLAG_RUNTIME));
     newCONSTSUB(stash, "FLAG_MSC_QUESTION_MARK_MEANS_OPTIONAL", newSViv(FLAG_MSC_QUESTION_MARK_MEANS_OPTIONAL));
+    newCONSTSUB(stash, "FLAG_MSC_EXCLAIMATION_MARK_MEANS_REQUIRED", newSViv(FLAG_MSC_EXCLAIMATION_MARK_MEANS_REQUIRED));
     newCONSTSUB(stash, "FLAG_MSC_NAMED_OPTIONAL_BY_DEFAULT",    newSViv(FLAG_MSC_NAMED_OPTIONAL_BY_DEFAULT));
     newCONSTSUB(stash, "HINTK_KEYWORDS", newSVpvs(HINTK_KEYWORDS));
     newCONSTSUB(stash, "HINTK_FLAGS_",   newSVpvs(HINTK_FLAGS_));

--- a/Parameters.xs
+++ b/Parameters.xs
@@ -964,6 +964,14 @@ static PADOFFSET parse_param(
     lex_read_space(0);
     c = lex_peek_unichar(0);
 
+    if (c == '?' && spec->flags & FLAG_MSC_QUESTION_MARK_MEANS_OPTIONAL) {
+        lex_read_unichar(0);
+        lex_read_space(0);
+
+        op_guard_update(ginit, newOP(OP_UNDEF, 0));
+        c = lex_peek_unichar(0);
+    }
+
     if (c == '=') {
         lex_read_unichar(0);
         lex_read_space(0);
@@ -982,12 +990,6 @@ static PADOFFSET parse_param(
             lex_read_space(0);
             c = lex_peek_unichar(0);
         }
-    } else if (c == '?' && spec->flags & FLAG_MSC_QUESTION_MARK_MEANS_OPTIONAL) {
-        lex_read_unichar(0);
-        lex_read_space(0);
-
-        op_guard_update(ginit, newOP(OP_UNDEF, 0));
-        c = lex_peek_unichar(0);
     } else if (*pflags & PARAM_NAMED && spec->flags & FLAG_MSC_NAMED_OPTIONAL_BY_DEFAULT) {
         if (c == '!') {
             lex_read_unichar(0);

--- a/lib/Function/Parameters.pm
+++ b/lib/Function/Parameters.pm
@@ -169,6 +169,7 @@ sub import {
         $clean{check_argument_count} = $clean{check_argument_types} = 1 if delete $type{strict};
 
         $clean{ms_compat_question_mark}  = _delete_default \%type, 'ms_compat_question_mark', 0;
+        $clean{ms_compat_exclaimation_mark}  = _delete_default \%type, 'ms_compat_exclaimation_mark', 0;
         $clean{ms_compat_named_optional} = _delete_default \%type, 'ms_compat_named_optional', 0;
 
         if (my $rt = delete $type{reify_type}) {
@@ -210,6 +211,7 @@ sub import {
         $flags |= FLAG_TYPES_OK     if $type->{types};
         $flags |= FLAG_RUNTIME      if $type->{runtime};
         $flags |= FLAG_MSC_QUESTION_MARK_MEANS_OPTIONAL if $type->{ms_compat_question_mark};
+        $flags |= FLAG_MSC_EXCLAIMATION_MARK_MEANS_REQUIRED if $type->{ms_compat_exclaimation_mark};
         $flags |= FLAG_MSC_NAMED_OPTIONAL_BY_DEFAULT    if $type->{ms_compat_named_optional};
         $^H{HINTK_FLAGS_ . $kw} = $flags;
         $^H{HINTK_SHIFT_ . $kw} = $type->{shift};

--- a/t/foreign/Method-Signatures/anon.t
+++ b/t/foreign/Method-Signatures/anon.t
@@ -1,14 +1,16 @@
 #!perl
+
 use strict;
 use warnings FATAL => 'all';
 
+use lib 't/lib';
 use Test::More 'no_plan';
 
 {
     package Stuff;
 
     use Test::More;
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
     method echo($arg) {
         return $arg

--- a/t/foreign/Method-Signatures/array_param.t
+++ b/t/foreign/Method-Signatures/array_param.t
@@ -1,13 +1,15 @@
 #!perl
+
 use strict;
 use warnings FATAL => 'all';
 
+use lib 't/lib';
 use Test::More tests => 3;
 
 {
     package Bla;
     use Test::More;
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
     method new ($class:) {
         bless {}, $class;

--- a/t/foreign/Method-Signatures/at_underscore.t
+++ b/t/foreign/Method-Signatures/at_underscore.t
@@ -1,15 +1,31 @@
-#!perl
+#!/usr/bin/env perl
+
+# Test the @_ signature
+
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Test::More;
 
+BEGIN {
+    TODO: {
+        local $TODO = '# F::P currently does not support the @_ signature.';
+        use Method::Signatures;
+
+        if( !ok( eval q[ func (@_){}; ] ) ) {
+            done_testing;
+            exit;
+        }
+    }
+}
+
 {
     package Foo;
-    use Function::Parameters qw(:strict);
-
-    fun foo { return @_ }
-    method bar { return @_ }
+    use Method::Signatures;
+    
+    func foo(@_) { return @_ }
+    method bar(@_) { return @_ }
 }
 
 is_deeply [Foo::foo()], [];

--- a/t/foreign/Method-Signatures/attributes.t
+++ b/t/foreign/Method-Signatures/attributes.t
@@ -1,7 +1,9 @@
 #!perl
+
 use strict;
 use warnings FATAL => 'all';
 
+use lib 't/lib';
 use Test::More 'no_plan';
 
 use attributes;
@@ -10,9 +12,9 @@ use attributes;
     package Stuff;
 
     use Test::More;
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
-    method echo($arg) {
+    method echo($arg) : method {
         return $arg;
     }
 
@@ -25,9 +27,9 @@ use attributes;
     package Foo;
 
     use Test::More;
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
-    my $code = fun () : method {};
+    my $code = func () : method {};
     is_deeply( [attributes::get $code], ['method'] );
 }
 
@@ -35,7 +37,8 @@ use attributes;
 {
     package Things;
 
-    use Function::Parameters qw(:strict);
+    use attributes;
+    use Method::Signatures;
 
     my $attrs;
     my $cb_called;

--- a/t/foreign/Method-Signatures/begin.t
+++ b/t/foreign/Method-Signatures/begin.t
@@ -4,11 +4,12 @@ package Foo;
 
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Test::More;
 use Test::Fatal;
 
-use Function::Parameters { method => { defaults => 'method', runtime => 0 } };
+use Method::Signatures;
 
 
 our $phase;
@@ -37,16 +38,16 @@ sub method_undefined
 method top_level_default() {}
 
 # Turn it off.
-use Function::Parameters { method => { defaults => 'method', runtime => 1 } };
+use Method::Signatures { compile_at_BEGIN => 0 };
 method top_level_off() {}
 
 # And on again.
-use Function::Parameters { method => { defaults => 'method', runtime => 0 } };
+use Method::Signatures { compile_at_BEGIN => 1 };
 method top_level_on() {}
 
 # Now turn it off inside a lexical scope
 {
-    use Function::Parameters { method => { defaults => 'method', runtime => 1 } };
+    use Method::Signatures { compile_at_BEGIN => 0 };
     method inner_scope_off() {}
 }
 

--- a/t/foreign/Method-Signatures/caller.t
+++ b/t/foreign/Method-Signatures/caller.t
@@ -1,6 +1,8 @@
 #!perl
-use warnings FATAL => 'all';
+
 use strict;
+use warnings FATAL => 'all';
+use lib 't/lib';
 
 # Test that caller() works
 
@@ -9,7 +11,7 @@ use strict;
 
     use Test::More 'no_plan';
 
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
     sub sub_caller {
         my($self, $level) = @_;

--- a/t/foreign/Method-Signatures/comments.t
+++ b/t/foreign/Method-Signatures/comments.t
@@ -1,21 +1,19 @@
 #!perl
+
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
-use Test::More
-    eval { require Moose }
-    ? (tests    => 5)
-    : (skip_all => "Moose required for testing types")
-;
+use Test::More;
 use Test::Fatal;
 
-use Function::Parameters qw(:strict);
+use Method::Signatures;
 
 
 is exception
 {
     eval q{
-        fun foo (
+        func foo (
             Int :$foo,              # this is foo
             Int :$bar               # this is bar
         )
@@ -27,10 +25,11 @@ is exception
 }, undef,
 'survives comments within the signature itself';
 
+
 is exception
 {
     eval q{
-        fun bar ( Int :$foo, Int :$bar )       # this is a signature
+        func bar ( Int :$foo, Int :$bar )       # this is a signature
         {
         }
 
@@ -39,49 +38,19 @@ is exception
 }, undef,
 'survives comments between signature and open brace';
 
-#SKIP:
-#{
-#    eval { require MooseX::Declare } or skip "MooseX::Declare required for this test", 1;
-#
-    is exception
-    {
-        eval q{
-#            use MooseX::Declare;
-#            use Method::Signatures::Modifiers;
 
-            package Foo
-            {
-                method bar ( Int :$foo, Int :$bar )     # this is a signature
-                {
-                }
-            }
-
-            1;
-        } or die;
-    }, undef,
-    'survives comments between signature and open brace';
-#}
-
-
-#TODO: {
-#    local $TODO = "closing paren in comment: rt.cpan.org 81364";
-
-    is exception
-    {
-#        # When this fails, it produces 'Variable "$bar" is not imported'
-#        # This is expected to fail, don't bother the user.
-#        no warnings;
-        eval q{
-            fun special_comment (
+is exception
+{
+    eval q{
+            func special_comment (
                 $foo, # )
                 $bar
             )
             { 42 }
             1;
         } or die;
-    }, undef,
-    'closing paren in comment';
-    is eval q[special_comment("this", "that")], 42;
-#}
+}, undef, 'closing paren in comment';
+is eval q[special_comment("this", "that")], 42;
 
-#done_testing();
+
+done_testing();

--- a/t/foreign/Method-Signatures/debugger.t
+++ b/t/foreign/Method-Signatures/debugger.t
@@ -1,43 +1,44 @@
 #!perl
+
 use strict;
 use warnings FATAL => 'all';
 
 use Dir::Self;
 use Test::More 'no_plan';
 
-#TODO: {
-#    todo_skip "This is still totally hosed", 2;
-
-    is eval {
-        local $SIG{ALRM} = sub { die "Alarm!\n"; };
-
-        alarm 5;
-        my $ret = qx{$^X "-Ilib" -le "package Foo;  use Function::Parameters;  method foo() { 42 } print Foo->foo()"};
-        alarm 0;
-        $ret;
-    }, "42\n", 'one-liner';
-    is $@, '';
-#}
-
+# So all the calls to $^X can find Function::Parameters and Method::Signatures
+$ENV{PERL5OPT} .= q[ -Mblib -It/lib ];
 
 is eval {
     local $SIG{ALRM} = sub { die "Alarm!\n"; };
 
     alarm 5;
-    my $ret = qx{$^X "-Ilib" -MFunction::Parameters -le "package Foo;  use Function::Parameters;  method foo() { 42 } print Foo->foo()"};
+    my $ret = qx{$^X -le "package Foo;  use Method::Signatures;  method foo() { 42 } print Foo->foo()"};
     alarm 0;
     $ret;
-}, "42\n", 'one liner with -MFunction::Parameters';
+}, "42\n", 'one-liner';
 is $@, '';
 
 
 is eval {
     local $SIG{ALRM} = sub { die "Alarm!\n"; };
-    my $simple_plx = __DIR__ . '/simple.plx';
 
+    alarm 5;
+    my $ret = qx{$^X -MMethod::Signatures -le "package Foo;  use Method::Signatures;  method foo() { 42 } print Foo->foo()"};
+    alarm 0;
+    $ret;
+}, "42\n", 'one liner with -MMethod::Signatures';
+is $@, '';
+
+
+is eval {
+    local $SIG{ALRM} = sub { die "Alarm!\n"; };
+
+    my $simple_plx = __DIR__ . '/simple.plx';
+    
     local $ENV{PERLDB_OPTS} = 'NonStop';
     alarm 5;
-    my $ret = qx{$^X "-Ilib" -dw $simple_plx};
+    my $ret = qx{$^X -dw $simple_plx};
     alarm 0;
     $ret;
 }, "42", 'debugger';

--- a/t/foreign/Method-Signatures/defaults.t
+++ b/t/foreign/Method-Signatures/defaults.t
@@ -1,31 +1,42 @@
-#!perl
+#!perl -w
+
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
-use Test::More 'no_plan';
+use Test::More;
+use Test::Fatal qw(lives_ok);
 
 {
     package Stuff;
 
     use Test::More;
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
     method add($this = 23, $that = 42) {
         return $this + $that;
-    }
-
-    method minus($this = 23, $that = 42) {
-        return $this - $that;
     }
 
     is( Stuff->add(),    23 + 42 );
     is( Stuff->add(99),  99 + 42 );
     is( Stuff->add(2,3), 5 );
 
-    is( Stuff->minus(),         23 - 42 );
-    is( Stuff->minus(99),       99 - 42 );
-    is( Stuff->minus(2, 3),     2 - 3 );
+    TODO: {
+        local $TODO = 'is ro not implemented';
+        
+        ok eval q[
+            method minus($this is ro = 23, $that is ro = 42) {
+                return $this - $that;
+            }
+            1;
+        ];
 
+        ok eval {
+            is( Stuff->minus(),         23 - 42 );
+            is( Stuff->minus(99),       99 - 42 );
+            is( Stuff->minus(2, 3),     2 - 3 );
+        };
+    }
 
     # Test that undef overrides defaults
     method echo($message = "what?") {
@@ -50,7 +61,7 @@ use Test::More 'no_plan';
 {
     package Bar;
     use Test::More;
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
     method hello($msg = "Hello, world!") {
         return $msg;
@@ -68,11 +79,20 @@ use Test::More 'no_plan';
     is( Bar->hi("Yo"),          "Yo" );
 
 
-#    method list(@args = (1,2,3)) {
-#        return @args;
-#    }
-#
-#    is_deeply [Bar->list()], [1,2,3];
+    TODO: {
+        local $TODO = 'defaults for lists not implemented';
+
+        ok eval q[
+            method list(@args = (1,2,3)) {
+                return @args;
+            }
+            1;
+        ];
+
+        ok eval {
+            is_deeply [Bar->list()], [1,2,3];
+        };
+    }
 
 
     method code($num, $code = sub { $num + 2 }) {
@@ -81,3 +101,48 @@ use Test::More 'no_plan';
 
     is( Bar->code(42), 44 );
 }
+
+note "Defaults are type checked"; {
+    package Biff;
+    use Test::More;
+    use Method::Signatures;
+
+    func hi(
+        Object $place = "World"
+    ) {
+        return "Hi, $place!\n";
+    }
+
+    ok !eval { hi() };
+    like $@, qr/parameter 1 \(\$place\): Validation failed/;
+}
+
+
+note "Multi-line defaults"; {
+    package Whatever;
+
+    use Method::Signatures;
+    use Test::More;
+
+    func stuff(
+        $arg = {
+            foo => 23,
+            bar => 42
+        }
+    ) {
+        return $arg->{foo};
+    }
+
+    is( stuff(), 23 );
+
+    func things(
+        $arg = "Hello
+There"
+    ) {
+        return $arg;
+    }
+
+    is( things(), "Hello\nThere" );
+}
+
+done_testing;

--- a/t/foreign/Method-Signatures/error_interruption.t
+++ b/t/foreign/Method-Signatures/error_interruption.t
@@ -1,6 +1,8 @@
 #!perl
+
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Dir::Self;
 use lib __DIR__ . "/lib";
@@ -8,8 +10,12 @@ use lib __DIR__ . "/lib";
 use Test::More;
 use Test::Fatal;
 
-like exception { require BarfyDie },
-  qr/requires explicit package name/,
-  "F:P doesn't interrupt real compilation error";
+ok !eval { require BarfyDie };
+TODO: {
+    local $TODO = 'Types obscure earlier compilation errors';
+
+    like $@, qr/requires explicit package name/,
+      "MS doesn't interrupt real compilation error";
+}
 
 done_testing();

--- a/t/foreign/Method-Signatures/func.t
+++ b/t/foreign/Method-Signatures/func.t
@@ -1,12 +1,14 @@
 #!perl
+
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Test::More tests => 1;
 
-use Function::Parameters qw(:strict);
+use Method::Signatures;
 
-fun echo($arg) {
+func echo($arg) {
     return $arg;
 }
 

--- a/t/foreign/Method-Signatures/into.t
+++ b/t/foreign/Method-Signatures/into.t
@@ -1,21 +1,28 @@
-#!perl
+#!perl -w
+
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
-# Importing always affects the currently compiling scope.
+# It should be possible to import into another package.
 
 package Foo;
 
 use Test::More 'no_plan';
 
-BEGIN {
-    package Bar;
-    require Function::Parameters;
-    Function::Parameters->import;
+TODO: {
+    local $TODO = 'into is not supported';
+    ok eval q[
+{ package Bar;
+  use Method::Signatures { into => 'Foo' };
 }
 
 is( Foo->foo(42), 42 );
 
 method foo ($arg) {
     return $arg;
+}
+
+1;
+];
 }

--- a/t/foreign/Method-Signatures/invocant.t
+++ b/t/foreign/Method-Signatures/invocant.t
@@ -4,12 +4,9 @@
 
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
-use Test::More
-    eval { require Moose }
-    ? (tests => 6)
-    : (skip_all => "Moose required for testing types")
-;
+use Test::More 'no_plan';
 
 our $skip_no_invocants;
 
@@ -17,7 +14,7 @@ our $skip_no_invocants;
     package Stuff;
 
     use Test::More;
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
     sub new { bless {}, __PACKAGE__ }
 
@@ -34,6 +31,10 @@ our $skip_no_invocants;
     }
 
     method without_space($class:$arg) {
+        $class->bar($arg);
+    }
+
+    method with_space_before_invocant( $class: $arg) {
         $class->bar($arg);
     }
 
@@ -62,9 +63,10 @@ our $skip_no_invocants;
 }
 
 
-is( Stuff->invocant,                0 );
-is( Stuff->with_arg(42),            42 );
-is( Stuff->without_space(42),       42 );
+is( Stuff->invocant,                            0 );
+is( Stuff->with_arg(42),                        42 );
+is( Stuff->without_space(42),                   42 );
+is( Stuff->with_space_before_invocant(42),      42 );
 
 my $stuff = Stuff->new;
 is( $stuff->no_invocant_class_type(Foo::Bar->new),     'Foo::Bar' );

--- a/t/foreign/Method-Signatures/larna.t
+++ b/t/foreign/Method-Signatures/larna.t
@@ -1,14 +1,16 @@
 #!perl
+
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Test::More;
 
-use Function::Parameters qw(:strict);
+use Method::Signatures;
 
 {
     my $a;
-    ok eval q{ $a = [ fun () {}, 1 ]; 1 }, 'anonymous function in list is okay'
+    ok eval q{ $a = [ func () {}, 1 ]; 1 }, 'anonymous function in list is okay'
         or diag "eval error: $@";
     is ref $a->[0], "CODE";
     is $a->[1], 1;

--- a/t/foreign/Method-Signatures/lib/Bad.pm
+++ b/t/foreign/Method-Signatures/lib/Bad.pm
@@ -2,7 +2,7 @@ package Bad;
 
 use strict;
 use warnings;
-use Function::Parameters qw(:strict);
+use Method::Signatures;
 
 ## $info->{} should be $info{}
 method meth1 ($foo) {
@@ -12,4 +12,4 @@ method meth1 ($foo) {
 
 method meth2 ($bar) {}
 
-'ok'
+1;

--- a/t/foreign/Method-Signatures/lib/BarfyDie.pm
+++ b/t/foreign/Method-Signatures/lib/BarfyDie.pm
@@ -5,15 +5,19 @@ package BarfyDie;
 use strict;
 use warnings;
 
-use Function::Parameters qw(:strict);
+use Function::Parameters;
 
 
 # This _should_ produce a simple error like the following:
 # Global symbol "$foo" requires explicit package name at t/lib/BarfyDie.pm line 13.
 $foo = 'hi!';
 
+# And, without the signature below, it would.
+# For that matter, if you compile this by itself, it still does.
+# However, when you require this file from inside an eval, Method::Signature's parser() method will
+# eat the error unless we localize $@ there.  So this verifies that we're doing that.
 
-method foo ($bar)
+method foo (Str $bar)
 {
 }
 

--- a/t/foreign/Method-Signatures/lib/MooseLoadTest.pm
+++ b/t/foreign/Method-Signatures/lib/MooseLoadTest.pm
@@ -4,7 +4,7 @@
 package Foo::Bar;
 
 use Moose;
-use Function::Parameters qw(:strict);
+use Method::Signatures;
 
 method check_int (Int $bar) {};
 method check_paramized_sref (ScalarRef[Num] $bar) {};

--- a/t/foreign/Method-Signatures/named.t
+++ b/t/foreign/Method-Signatures/named.t
@@ -1,6 +1,7 @@
 #!perl
 use warnings FATAL => 'all';
 use strict;
+use lib 't/lib';
 
 use Test::More;
 
@@ -9,7 +10,7 @@ use Test::More;
 
     use Test::More;
     use Test::Fatal;;
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
     method formalize($text, :$justify = "left", :$case = undef) {
         my %params;

--- a/t/foreign/Method-Signatures/odd_number.t
+++ b/t/foreign/Method-Signatures/odd_number.t
@@ -16,6 +16,6 @@ method foo(:$name, :$value) {
 }
 
 like exception { Foo->foo(name => 42, value =>) },
-  qr/Too few arguments for method foo/;
+  qr/Odd number of paired arguments for method foo/;
 
 done_testing;

--- a/t/foreign/Method-Signatures/odd_number.t
+++ b/t/foreign/Method-Signatures/odd_number.t
@@ -1,17 +1,21 @@
 #!perl
 
-use warnings FATAL => 'all';
-use strict;
+package Foo;
 
-use Test::More tests => 1;
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::More;
 use Test::Fatal;
 
-use Function::Parameters qw(:strict);
+use Method::Signatures;
 
-package Foo {
-    method foo(:$name, :$value) {
-        return $name, $value;
-    }
+method foo(:$name, :$value) {
+    return $name, $value;
 }
 
-like exception { Foo->foo(name => 42, value =>) }, qr/Too few arguments.+ line 17/;
+like exception { Foo->foo(name => 42, value =>) },
+  qr/Too few arguments for method foo/;
+
+done_testing;

--- a/t/foreign/Method-Signatures/one_line.t
+++ b/t/foreign/Method-Signatures/one_line.t
@@ -1,12 +1,15 @@
 #!perl
-use warnings FATAL => 'all';
+
 use strict;
+use warnings FATAL => 'all';
+use lib 't/lib';
+
 use Test::More tests => 1;
 
 {
     package Thing;
 
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
     method foo {"wibble"}
 
     ::is( Thing->foo, "wibble" );

--- a/t/foreign/Method-Signatures/optional.t
+++ b/t/foreign/Method-Signatures/optional.t
@@ -1,9 +1,10 @@
 #!perl
 
-# Test the $arg = undef optional syntax.
+# Test the $arg? optional syntax.
 
 use strict;
-use warnings FATAL => 'all';
+use warnings;
+use lib 't/lib';
 
 use Test::More;
 
@@ -11,22 +12,22 @@ use Test::More;
     package Stuff;
 
     use Test::More;
-    use Test::Fatal;
-    use Function::Parameters qw(:strict);
+    use Test::Fatal qw(lives_ok);
+    use Method::Signatures;
 
-    method whatever($this = undef) {
+    method whatever($this?) {
         return $this;
     }
 
     is( Stuff->whatever(23),    23 );
 
-    method things($this = 99) {
+    method things($this? = 99) {
         return $this;
     }
 
     is( Stuff->things(),        99 );
 
-    method some_optional($that, $this = undef) {
+    method some_optional($that, $this?) {
         return $that + ($this || 0);
     }
 
@@ -34,10 +35,11 @@ use Test::More;
     is( Stuff->some_optional(18), 18 );
 
 
-    method named_params(:$this = undef, :$that = undef) {}
+    # are named parameters optional by default?
+    method named_params(:$this, :$that) {}
 
-    is exception { Stuff->named_params(this => 0) }, undef, 'can leave out some named params';
-    is exception { Stuff->named_params(         ) }, undef, 'can leave out all named params';
+    lives_ok { Stuff->named_params(this => 0) } 'can leave out some named params';
+    lives_ok { Stuff->named_params(         ) } 'can leave out all named params';
 
 
     # are slurpy parameters optional by default?
@@ -45,9 +47,9 @@ use Test::More;
     method slurpy_param($this, $that = 0, @other) {}
 
     my @a = ();
-    is exception { Stuff->slurpy_param(0, 0, @a) }, undef, 'can pass empty array to slurpy param';
-    is exception { Stuff->slurpy_param(0, 0    ) }, undef, 'can omit slurpy param altogether';
-    is exception { Stuff->slurpy_param(0       ) }, undef, 'can omit other optional params as well as slurpy param';
+    lives_ok { Stuff->slurpy_param(0, 0, @a) } 'can pass empty array to slurpy param';
+    lives_ok { Stuff->slurpy_param(0, 0    ) } 'can omit slurpy param altogether';
+    lives_ok { Stuff->slurpy_param(0       ) } 'can omit other optional params as well as slurpy param';
 }
 
 

--- a/t/foreign/Method-Signatures/paren_on_own_line.t
+++ b/t/foreign/Method-Signatures/paren_on_own_line.t
@@ -4,8 +4,9 @@ package Foo;
 
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
-use Function::Parameters qw(:strict);
+use Method::Signatures;
 use Test::More 'no_plan';
 
 # The problem goes away inside an eval STRING.

--- a/t/foreign/Method-Signatures/paren_plus_open_block.t
+++ b/t/foreign/Method-Signatures/paren_plus_open_block.t
@@ -2,11 +2,12 @@
 
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 package Foo;
 
 use Test::More "no_plan";
-use Function::Parameters qw(:strict);
+use Method::Signatures;
 
 method foo(
     $arg

--- a/t/foreign/Method-Signatures/required.t
+++ b/t/foreign/Method-Signatures/required.t
@@ -1,7 +1,10 @@
 #!perl
 
+# Test the $arg! required syntax
+
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Test::More;
 
@@ -11,23 +14,29 @@ use Test::More;
 
     use Test::More;
     use Test::Fatal;
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
-    method whatever($this) {
+    method whatever($this!) {
         return $this;
     }
 
     is( Stuff->whatever(23),    23 );
 
-    like exception { Stuff->whatever() }, qr/Too few arguments/;
+#line 23
+    like exception { Stuff->whatever() },
+      qr{Too few arguments for method whatever},
+      'simple required param error okay';
 
-    method some_optional($that, $this = 22) {
+    method some_optional($that!, $this = 22) {
         return $that + $this
     }
 
     is( Stuff->some_optional(18), 18 + 22 );
 
-    like exception { Stuff->some_optional() }, qr/Too few arguments/;
+#line 33
+    like exception { Stuff->some_optional() },
+      qr{Too few arguments for method some_optional},
+      'some required/some not required param error okay';
 }
 
 

--- a/t/foreign/Method-Signatures/simple.plx
+++ b/t/foreign/Method-Signatures/simple.plx
@@ -2,8 +2,9 @@ package Foo;
 
 use strict;
 use warnings;
+use lib 't/lib';
 
-use Function::Parameters;
+use Method::Signatures;
 
 method echo($msg) {
     return $msg

--- a/t/foreign/Method-Signatures/syntax_errors.t
+++ b/t/foreign/Method-Signatures/syntax_errors.t
@@ -1,6 +1,8 @@
 #!perl
+
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Test::More;
 
@@ -8,12 +10,6 @@ use Dir::Self;
 use lib __DIR__ . '/lib';
 
 ok !eval { require Bad };
-#TODO: {
-#    local $TODO = "The user should see the actual syntax error";
-    like $@, qr{^Global symbol "\$info" requires explicit package name}m;
-
-#    like($@, qr{^PPI failed to find statement for '\$bar'}m,
-#         'Bad syntax generates stack trace');
-#}
+like $@, qr{^Global symbol "\$info" requires explicit package name}ms;
 
 done_testing();

--- a/t/foreign/Method-Signatures/too_many_args.t
+++ b/t/foreign/Method-Signatures/too_many_args.t
@@ -2,31 +2,32 @@
 
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Test::More;
 
-use Function::Parameters qw(:strict);
+use Method::Signatures { compile_at_BEGIN => 0 };
 
-fun no_sig { return @_ }
-fun no_args() { return @_ }
-fun one_arg($foo) { return $foo }
-fun two_args($foo, $bar) { return ($foo, $bar) }
-fun array_at_end($foo, @stuff) { return ($foo, @stuff) }
-fun one_named(:$foo) { return $foo; }
-fun one_named_one_positional($bar, :$foo) { return($foo, $bar) }
+func no_sig { return @_ }
+func no_args() { return @_ }
+func one_arg($foo) { return $foo }
+func two_args($foo, $bar) { return ($foo, $bar) }
+func array_at_end($foo, @stuff) { return ($foo, @stuff) }
+func one_named(:$foo) { return $foo; }
+func one_named_one_positional($bar, :$foo) { return($foo, $bar) }
 
 note "too many arguments"; {
-    is_deeply [no_sig(42)], [42];
-
+    ok !eval { no_sig(42); 1 },                                   "no args";
+    like $@, qr{Too many arguments for func no_sig \(expected 0, got 1\) };
 
     ok !eval { no_args(42); 1 },                                   "no args";
-    like $@, qr{Too many arguments};
+    like $@, qr{Too many arguments for func no_args \(expected 0, got 1\)};
 
     ok !eval { one_arg(23, 42); 1 },                               "one arg";
-    like $@, qr{Too many arguments};
+    like $@, qr{Too many arguments for func one_arg \(expected 1, got 2\)};
 
     ok !eval { two_args(23, 42, 99); 1 },                          "two args";
-    like $@, qr{Too many arguments};
+    like $@, qr{Too many arguments for func two_args \(expected 2, got 3\)};
 
     is_deeply [array_at_end(23, 42, 99)], [23, 42, 99],         "array at end";
 }
@@ -34,13 +35,13 @@ note "too many arguments"; {
 
 note "with positionals"; {
     is one_named(foo => 42), 42;
-    is one_named(foo => 23, foo => 42), 42;
-
+    ok !eval { one_named(foo => 23, foo => 42); 1 };
+    like $@, qr{one_named\(\), was given too many arguments; it expects 1};
 
 
     is_deeply [one_named_one_positional(23, foo => 42)], [42, 23];
-    is_deeply [one_named_one_positional(23, foo => 42, foo => 23)], [23, 23];
-
+    ok !eval { one_named_one_positional(23, foo => 42, foo => 23); 1 };
+    like $@, qr{one_named_one_positional\(\), was given too many arguments; it expects 2};
 }
 
 

--- a/t/foreign/Method-Signatures/trailing_comma.t
+++ b/t/foreign/Method-Signatures/trailing_comma.t
@@ -4,12 +4,13 @@
 
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Test::More;
 
-use Function::Parameters qw(:strict);
+use Method::Signatures;
 
-fun foo($foo, $bar,) {
+func foo($foo, $bar,) {
     return [$foo, $bar];
 }
 

--- a/t/foreign/Method-Signatures/typeload_moose.t
+++ b/t/foreign/Method-Signatures/typeload_moose.t
@@ -2,6 +2,8 @@
 
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
+
 use Dir::Self;
 use lib __DIR__ . '/lib';
 

--- a/t/foreign/Method-Signatures/typeload_notypes.t
+++ b/t/foreign/Method-Signatures/typeload_notypes.t
@@ -1,7 +1,8 @@
-#!perl
+#!/usr/bin/perl
 
 use strict;
 use warnings FATAL => 'all';
+use lib 't/lib';
 
 use Test::More;
 
@@ -9,10 +10,7 @@ use Test::More;
 {
     package Foo::Bar;
 
-    use strict;
-    use warnings;
-
-    use Function::Parameters qw(:strict);
+    use Method::Signatures;
 
     method new ($class:) { bless {}, $class; }
 

--- a/t/lib/Method/Signatures.pm
+++ b/t/lib/Method/Signatures.pm
@@ -47,8 +47,9 @@ sub import {
     my %fp_opts = (
         runtime => 0,
         reify_type => sub { Method::Signatures->_make_constraint($_[0]) },
-        ms_compat_question_mark => 1,
-        ms_compat_named_optional => 1,
+        ms_compat_question_mark         => 1,
+        ms_compat_exclaimation_mark     => 1,
+        ms_compat_named_optional        => 1,
     );
 
     # Adapt compile_at_BEGIN

--- a/t/lib/Method/Signatures.pm
+++ b/t/lib/Method/Signatures.pm
@@ -47,6 +47,8 @@ sub import {
     my %fp_opts = (
         runtime => 0,
         reify_type => sub { Method::Signatures->_make_constraint($_[0]) },
+        ms_compat_question_mark => 1,
+        ms_compat_named_optional => 1,
     );
 
     # Adapt compile_at_BEGIN

--- a/t/lib/Method/Signatures.pm
+++ b/t/lib/Method/Signatures.pm
@@ -1,0 +1,161 @@
+package Method::Signatures;
+
+use strict;
+use warnings;
+use Carp;
+
+our $VERSION = '20150222';
+
+use Function::Parameters ();
+
+=head1 NAME
+
+Method::Signatures - A compatibility wrapper around Function::Parameters
+
+=head1 Differences
+
+=head2 Lexical vs Package
+
+Method::Signatures works per package, but Function::Parameters is lexical.
+
+=head2 Unsupported Features
+
+=head3 into
+
+C<< use Method::Signatures { into => 'Some::Other::Class' } >> is not
+supported.
+
+The most common use of C<into> is when writing a wrapper around
+Method::Signatures.  This can be done like so.
+
+    sub import {
+        require Method::Signatures;
+        Method::Signatures->import;
+    }
+
+See L<Function::Parameters/Wrapping "Function::Parameters"> for details.
+
+=cut
+
+sub import {
+    my $class = shift;
+    my $ms_opts  = shift;
+
+    croak "into is not supported, see the documentation for alternatives"
+      if $ms_opts->{into};
+    
+    my %fp_opts = (
+        runtime => 0,
+        reify_type => sub { Method::Signatures->_make_constraint($_[0]) },
+    );
+
+    # Adapt compile_at_BEGIN
+    $fp_opts{runtime} = $ms_opts->{compile_at_BEGIN} ? 0 : 1
+      if exists $ms_opts->{compile_at_BEGIN};
+
+    Function::Parameters->import({
+        func    => {
+            defaults => 'function_strict',
+            %fp_opts,
+        },
+        method  => {
+            defaults => 'method_strict',
+            %fp_opts,
+        },
+    });
+
+    return;
+}
+
+
+# STUFF FOR TYPE CHECKING
+
+# This variable will hold all the bits we need.  MUTC could stand for Moose::Util::TypeConstraint,
+# or it could stand for Mouse::Util::TypeConstraint ... depends on which one you've got loaded (or
+# Mouse if you have neither loaded).  Because we use Any::Moose to allow the user to choose
+# whichever they like, we'll need to figure out the exact method names to call.  We'll also need a
+# type constraint cache, where we stick our constraints once we find or create them.  This insures
+# that we only have to run down any given constraint once, the first time it's seen, and then after
+# that it's simple enough to pluck back out.  This is very similar to how MooseX::Params::Validate
+# does it.
+our %mutc;
+
+# This is a helper function to initialize our %mutc variable.
+sub _init_mutc
+{
+    require Any::Moose;
+    Any::Moose->import('::Util::TypeConstraints');
+
+    no strict 'refs';
+    my $class = any_moose('::Util::TypeConstraints');
+    $mutc{class} = $class;
+
+    $mutc{findit}     = \&{ $class . '::find_or_parse_type_constraint' };
+    $mutc{pull}       = \&{ $class . '::find_type_constraint'          };
+    $mutc{make_class} = \&{ $class . '::class_type'                    };
+    $mutc{make_role}  = \&{ $class . '::role_type'                     };
+
+    $mutc{isa_class}  = $mutc{pull}->("ClassName");
+    $mutc{isa_role}   = $mutc{pull}->("RoleName");
+}
+
+# This is a helper function to find (or create) the constraint we need for a given type.  It would
+# be called when the type is not found in our cache.
+sub _make_constraint
+{
+    my ($class, $type) = @_;
+
+    _init_mutc() unless $mutc{class};
+
+    # Look for basic types (Int, Str, Bool, etc).  This will also create a new constraint for any
+    # parameterized types (e.g. ArrayRef[Int]) or any disjunctions (e.g. Int|ScalarRef[Int]).
+    my $constr = eval { $mutc{findit}->($type) };
+    if ($@)
+    {
+        $class->signature_error("the type $type is unrecognized (looks like it doesn't parse correctly)");
+    }
+    return $constr if $constr;
+
+    # Check for roles.  Note that you *must* check for roles before you check for classes, because a
+    # role ISA class.
+    return $mutc{make_role}->($type) if $mutc{isa_role}->check($type);
+
+    # Now check for classes.
+    return $mutc{make_class}->($type) if $mutc{isa_class}->check($type);
+
+    $class->signature_error("the type $type is unrecognized (perhaps you forgot to load it?)");
+}
+
+# This method does the actual type checking.  It's what we inject into our user's method, to be
+# called directly by them.
+#
+# Note that you can override this instead of inject_for_type_check if you'd rather.  If you do,
+# remember that this is a class method, not an object method.  That's because it's called at
+# runtime, when there is no Method::Signatures object still around.
+sub type_check
+{
+    my ($class, $type, $value, $name) = @_;
+
+    # find it if isn't cached
+    $mutc{cache}->{$type} ||= $class->_make_constraint($type);
+
+    # throw an error if the type check fails
+    unless ($mutc{cache}->{$type}->check($value))
+    {
+        $class->type_error($type, $value, $name);
+    }
+
+    # $mutc{cache} = {};
+}
+
+# If you just want to change what the type failure errors look like, just override this.
+# Note that you can call signature_error yourself to handle the croak-like aspects.
+sub type_error
+{
+    my ($class, $type, $value, $name) = @_;
+    $value = defined $value ? qq{"$value"} : 'undef';
+    $class->signature_error(qq{the '$name' parameter ($value) is not of type $type});
+}
+
+
+1;


### PR DESCRIPTION
This pull request is not ready for prime time, but I wanted to push it so you can work on top of it and so we don't duplicate efforts.

This pull request...
* Adds a Method::Signatures compatibility wrapper in t/lib
* Updates t/foreign/Method-Signatures/ to use it
* Updates those tests to match the latest from Method-Signatures
* Implements `$foo!`
* Implements `$foo? = "default"

It has these problems...
* The `-fsanitize` code was chopped out because there's no way to turn it off.
* named.t is failing because `method wrong( $foo, $bar = undef, :$named ) {}` should be disallowed, I don't think the checker takes optional named parameters into account.
* type_check.t is failing because unknown types are being interpreted as class methods.
* slurpy.t is failing because F::P considers all slurpies optional even with `@foo!`.
* too_many_args.t is failing because...
  * no signature should be the same as an empty signature
  * `$obj->method( foo => 23, foo => 42 )` should be an error in M::S.
