### PR TITLE
Relegated error reporting to Carp::confess

### DIFF
--- a/lib/Function/Parameters.pm
+++ b/lib/Function/Parameters.pm
@@ -6,8 +6,8 @@ use warnings;
 use Carp qw(croak confess);
 
 sub _croak {
-    my (undef, $file, $line) = caller 1;
-    die @_, " at $file line $line.\n";
+    local($Carp::CarpLevel) = 1;
+    confess("@_");
 }
 
 use XSLoader;

--- a/t/croak.t
+++ b/t/croak.t
@@ -42,17 +42,17 @@ my $marker = __LINE__;
     fun worngt1() { taket "X" }
 }
 
-is exception { Crabs::take2 1 }, "Too few arguments for fun take2 (expected 2, got 1) at ${\__FILE__} line ${\__LINE__}.\n";
-is exception { Crabs::worng1 },  "Too few arguments for fun take2 (expected 2, got 1) at ${\__FILE__} line ${\($marker + 5)}.\n";
-is exception { Crabs::take2 1, 2, 3, 4 }, "Too many arguments for fun take2 (expected 2, got 4) at ${\__FILE__} line ${\__LINE__}.\n";
-is exception { Crabs::worng4 },           "Too many arguments for fun take2 (expected 2, got 4) at ${\__FILE__} line ${\($marker + 6)}.\n";
+like exception { Crabs::take2 1 }, qr/Too few arguments for fun take2 \(expected 2, got 1\)/;
+like exception { Crabs::worng1 },  qr/Too few arguments for fun take2 \(expected 2, got 1\)/;
+like exception { Crabs::take2 1, 2, 3, 4 }, qr/Too many arguments for fun take2 \(expected 2, got 4\)/;
+like exception { Crabs::worng4 },           qr/Too many arguments for fun take2 \(expected 2, got 4\)/;
 
-is exception { Crabs::takekw "a", "b", "c" }, "Odd number of paired arguments for fun takekw at ${\__FILE__} line ${\__LINE__}.\n";
-is exception { Crabs::worngkw1 },             "Odd number of paired arguments for fun takekw at ${\__FILE__} line ${\($marker + 9)}.\n";
-is exception { Crabs::takekw a => 1 }, "In fun takekw: missing named parameter: zomg at ${\__FILE__} line ${\__LINE__}.\n";
-is exception { Crabs::worngkw2 },      "In fun takekw: missing named parameter: zomg at ${\__FILE__} line ${\($marker + 10)}.\n";
-is exception { Crabs::takekw zomg => 1, a => 2 }, "In fun takekw: no such named parameter: a at ${\__FILE__} line ${\__LINE__}.\n";
-is exception { Crabs::worngkw4 },                 "In fun takekw: no such named parameter: a at ${\__FILE__} line ${\($marker + 11)}.\n";
+like exception { Crabs::takekw "a", "b", "c" }, qr/Odd number of paired arguments for fun takekw/;
+like exception { Crabs::worngkw1 },             qr/Odd number of paired arguments for fun takekw/;
+like exception { Crabs::takekw a => 1 }, qr/In fun takekw: missing named parameter: zomg/;
+like exception { Crabs::worngkw2 },      qr/In fun takekw: missing named parameter: zomg/;
+like exception { Crabs::takekw zomg => 1, a => 2 }, qr/In fun takekw: no such named parameter: a/;
+like exception { Crabs::worngkw4 },                 qr/In fun takekw: no such named parameter: a/;
 
-is exception { Crabs::taket "X" }, "In fun taket: parameter 1 (\$x): A failure (Cool[Story]) of X at ${\__FILE__} line ${\__LINE__}.\n";
-is exception { Crabs::worngt1 },   "In fun taket: parameter 1 (\$x): A failure (Cool[Story]) of X at ${\__FILE__} line ${\($marker + 14)}.\n";
+like exception { Crabs::taket "X" }, qr/In fun taket: parameter 1 \(\$x\): A failure \(Cool\[Story\]\) of X/;
+like exception { Crabs::worngt1 },   qr/In fun taket: parameter 1 \(\$x\): A failure \(Cool\[Story\]\) of X/;

--- a/t/foreign/Method-Signatures/odd_number.t
+++ b/t/foreign/Method-Signatures/odd_number.t
@@ -14,4 +14,4 @@ package Foo {
     }
 }
 
-like exception { Foo->foo(name => 42, value =>) }, qr/Too few arguments.+ line 17/;
+like exception { Foo->foo(name => 42, value =>) }, qr/Too few arguments./;


### PR DESCRIPTION
Hello Lukas,
Thank you for writing this nice piece. I'm using this in my projects (btw I asked this module to be added into debian (they agreed) and probably it'll trickle to ubuntu as well), this module is by far superior offering on CPAN for this task.
However the error reporting is not really descriptive. In real world reporting only one frame is really inadequate for the debugging of any complex software package.
Please consider applying this patch.
Thank you!  