### PR TITLE
build check libasan $?

### DIFF
--- a/maint/eumm-fixup.pl
+++ b/maint/eumm-fixup.pl
@@ -31,7 +31,7 @@ __EOT__
             for my $libasan (qw(libasan.so)) {
                 local $ENV{LD_PRELOAD} = join ' ', $libasan, $ENV{LD_PRELOAD} || ();
                 my $out = `"$^X" -e 0 2>&1`;
-                if ($out eq '') {
+                if ($out eq '' and $? == 0) {
                     $preload_libasan = $libasan;
                     last;
                 } else {


### PR DESCRIPTION
On my system, for whatever reason, setting `$ENV{LD_PRELOAD}` causes a segfault, probably in the shell. This happens before the redirection happens, so the captured text is empty. This is a false positive. The check here avoids that false positive.