### PR TITLE
support type coercion

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -657,6 +657,13 @@ available configuration options are:
 
     Default: `1`
 
+- `coerce_argument_types`
+
+    (boolean) Whether functions declared with this keyword should coerce the values
+    of the arguments they are called with to the types declared.
+
+    Default: `0`
+
 - `default_arguments`
 
     (boolean) Whether functions declared with this keyword should allow default

--- a/lib/Function/Parameters.pm
+++ b/lib/Function/Parameters.pm
@@ -342,6 +342,7 @@ sub import {
         $clean{runtime}              = _delete_default \%type, 'runtime',              0;
         $clean{check_argument_count} = _delete_default \%type, 'check_argument_count', 1;
         $clean{check_argument_types} = _delete_default \%type, 'check_argument_types', 1;
+        $clean{coerce_argument_types} = _delete_default \%type, 'coerce_argument_types', 0;
 
         %type and confess "Invalid keyword property: @{[sort keys %type]}";
 
@@ -360,6 +361,7 @@ sub import {
         $flags |= FLAG_DEFAULT_ARGS if $type->{default_arguments};
         $flags |= FLAG_CHECK_NARGS  if $type->{check_argument_count};
         $flags |= FLAG_CHECK_TARGS  if $type->{check_argument_types};
+        $flags |= FLAG_COERCE_TARGS if $type->{coerce_argument_types};
         $flags |= FLAG_INVOCANT     if $type->{invocant};
         $flags |= FLAG_NAMED_PARAMS if $type->{named_parameters};
         $flags |= FLAG_TYPES_OK     if $type->{types};
@@ -1068,6 +1070,13 @@ L<type constraints|/Type constraints> are parsed but silently ignored. If true,
 an exception is thrown if an argument fails a type check.
 
 Default: C<1>
+
+=item C<coerce_argument_types>
+
+(boolean) Whether functions declared with this keyword should coerce the values
+of the arguments they are called with to the types declared.
+
+Default: C<0>
 
 =item C<default_arguments>
 

--- a/t/types_coerce.t
+++ b/t/types_coerce.t
@@ -1,0 +1,60 @@
+#!perl
+use warnings FATAL => 'all';
+use strict;
+
+use Test::More
+    eval { require Type::Library }
+    ? ()
+    : (skip_all => "Type::Library required for testing type coercion");
+
+BEGIN {
+    package MyTC {
+        use Type::Library
+          -base,
+          -declare => qw(MyArrayRef);
+        use Type::Utils -all;
+        use Types::Standard -types;
+
+        declare MyArrayRef, as ArrayRef;
+        coerce MyArrayRef, from Any, via { [$_] };
+    };
+
+    MyTC->import('MyArrayRef');
+}
+
+use Function::Parameters;
+
+my $re_error = qr/did not pass type constraint/;
+
+eval {
+    ( fun( MyArrayRef $x) { } )->(1);
+};
+like( $@, $re_error, 'coerce mode off, positional' );
+
+eval {
+    ( fun( MyArrayRef : $x ) { } )->( x => 1 );
+};
+like( $@, $re_error, 'coerce mode off, named' );
+
+eval {
+    ( fun( MyArrayRef @rest ) { } )->(1);
+};
+like( $@, $re_error, 'coerce mode off, slurp array' );
+
+eval {
+    ( fun( MyArrayRef %rest ) { } )->( x => 1 );
+};
+like( $@, $re_error, 'coerce mode off, slurp hash' );
+
+use Function::Parameters { fun => { coerce_argument_types => 1 } };
+
+is_deeply( ( fun( MyArrayRef $x) { $x } )->(1), [1], 'positional' );
+is_deeply( ( fun( MyArrayRef : $x ) { $x } )->( x => 1 ), [1], 'named' );
+is_deeply( ( fun( MyArrayRef @rest ) { \@rest } )->( 1, [2], 3 ),
+    [ [1], [2], [3] ],
+    'slurp array' );
+is_deeply( ( fun( MyArrayRef %rest ) { \%rest } )->( x => 1, y => [2], z => 3 ),
+    { x => [1], y => [2], z => [3] },
+    'slurp hash' );
+
+done_testing;


### PR DESCRIPTION
This is for #34 

This would add a new option "coerce_argument_types", which defaults to 0. Once enabled it would do type coersion like below, before type checking. 
```perl
$value = $type->can('has_coercion') && $type->has_coercion ? $type->coerce($value) : $value;
```